### PR TITLE
Children detail made public and added test cases

### DIFF
--- a/clubs/permissions.py
+++ b/clubs/permissions.py
@@ -10,7 +10,7 @@ class ClubPermission(permissions.BasePermission):
     Anyone with permission should be able to create.
     """
     def has_object_permission(self, request, view, obj):
-        if view.action in ['retrieve']:
+        if view.action in ['retrieve', 'children']:
             return True
 
         membership = Membership.objects.filter(person=request.user, club=obj).first()
@@ -23,7 +23,7 @@ class ClubPermission(permissions.BasePermission):
             return membership.role <= Membership.ROLE_OFFICER
 
     def has_permission(self, request, view):
-        if view.action in ['update', 'upload', 'partial_update', 'destroy']:
+        if view.action in ['update', 'upload', 'children', 'partial_update', 'destroy']:
             return request.user.is_authenticated
         elif view.action in ['create']:
             return request.user.is_authenticated and request.user.is_superuser

--- a/tests/clubs/test_models.py
+++ b/tests/clubs/test_models.py
@@ -21,6 +21,7 @@ class ClubTestCase(TestCase):
         self.assertEqual(self.club2.parent_orgs.first(), self.club1)
         self.assertEqual(self.club1.children_orgs.first(), self.club2)
 
+
 class EventTestCase(TestCase):
     def setUp(self):
         date = pytz.timezone('America/New_York').localize(datetime.datetime(2019, 1, 1))

--- a/tests/clubs/test_models.py
+++ b/tests/clubs/test_models.py
@@ -10,11 +10,16 @@ from clubs.models import Badge, Club, Event, Favorite, Membership, Tag
 class ClubTestCase(TestCase):
     def setUp(self):
         date = pytz.timezone('America/New_York').localize(datetime.datetime(2019, 1, 1))
-        self.club = Club.objects.create(code='a', name='a', subtitle='a', founded=date, description='a', size=1)
+        self.club1 = Club.objects.create(code='a', name='a', subtitle='a', founded=date, description='a', size=1)
+        self.club2 = Club.objects.create(code='b', name='b', subtitle='b', founded=date, description='b', size=1)
+        self.club2.parent_orgs.add(self.club1)
 
     def test_str(self):
-        self.assertEqual(str(self.club), self.club.name)
+        self.assertEqual(str(self.club1), self.club1.name)
 
+    def test_parent_children(self):
+        self.assertEqual(self.club2.parent_orgs.first(), self.club1)
+        self.assertEqual(self.club1.children_orgs.first(), self.club2)
 
 class EventTestCase(TestCase):
     def setUp(self):

--- a/tests/clubs/test_views.py
+++ b/tests/clubs/test_views.py
@@ -618,6 +618,14 @@ class ClubTestCase(TestCase):
         resp = self.client.get(reverse('clubs-detail', args=(self.club1.code,)))
         self.assertIn(resp.status_code, [200], resp.content)
 
+    def test_club_children(self):
+        """
+        Any user should be able to view clubs children tree.
+        """
+        self.client.login(username=self.user3.username, password='test')
+        resp = self.client.get(reverse('clubs-children', args=(self.club1.code,)))
+        self.assertIn(resp.status_code, [200], resp.content)
+
     def test_club_modify(self):
         """
         Owners and officers should be able to modify the club.


### PR DESCRIPTION
- Permissions.py modified to make the /children detail viewable by anyone
- Test cases added in test_models.py for parent_orgs and children_orgs
- Test cases added in test_views.py for /children detail