### PR TITLE
Remove unused information from club list endpoint

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -231,11 +231,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
@@ -301,10 +301,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
-                "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
+                "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
+                "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"
             ],
-            "version": "==1.9.4"
+            "version": "==1.9.5"
         },
         "sqlparse": {
             "hashes": [

--- a/clubs/serializers.py
+++ b/clubs/serializers.py
@@ -157,10 +157,10 @@ class AuthenticatedMembershipSerializer(MembershipSerializer):
 
 
 class ClubListSerializer(serializers.ModelSerializer):
-    '''
+    """
     The club list serializer returns a subset of the information that the full serializer returns.
     This is done for a quicker response.
-    '''
+    """
     code = serializers.SlugField(required=False, validators=[validators.UniqueValidator(queryset=Club.objects.all())])
     name = serializers.CharField(validators=[validators.UniqueValidator(queryset=Club.objects.all())])
     subtitle = serializers.CharField(required=False)

--- a/clubs/serializers.py
+++ b/clubs/serializers.py
@@ -156,17 +156,17 @@ class AuthenticatedMembershipSerializer(MembershipSerializer):
         fields = MembershipSerializer.Meta.fields + ['email', 'username']
 
 
-class ClubSerializer(serializers.ModelSerializer):
+class ClubListSerializer(serializers.ModelSerializer):
+    '''
+    The club list serializer returns a subset of the information that the full serializer returns.
+    This is done for a quicker response.
+    '''
     code = serializers.SlugField(required=False, validators=[validators.UniqueValidator(queryset=Club.objects.all())])
     name = serializers.CharField(validators=[validators.UniqueValidator(queryset=Club.objects.all())])
-    tags = TagSerializer(many=True)
     subtitle = serializers.CharField(required=False)
-    members = MembershipSerializer(many=True, source='membership_set', read_only=True)
-    favorite_count = serializers.IntegerField(read_only=True)
-    image = serializers.ImageField(write_only=True, required=False)
+    tags = TagSerializer(many=True)
     image_url = serializers.SerializerMethodField('get_image_url')
-    parent_orgs = serializers.SerializerMethodField('get_parent_orgs')
-    badges = BadgeSerializer(many=True, required=False)
+    favorite_count = serializers.IntegerField(read_only=True)
 
     def get_image_url(self, obj):
         if not obj.image:
@@ -175,6 +175,20 @@ class ClubSerializer(serializers.ModelSerializer):
             return obj.image.url
         else:
             return self.context['request'].build_absolute_uri(obj.image.url)
+
+    class Meta:
+        model = Club
+        fields = [
+            'name', 'code', 'description', 'founded', 'size', 'email', 'tags', 'subtitle',
+            'application_required', 'accepting_members', 'image_url', 'favorite_count', 'active'
+        ]
+
+
+class ClubSerializer(ClubListSerializer):
+    members = MembershipSerializer(many=True, source='membership_set', read_only=True)
+    image = serializers.ImageField(write_only=True, required=False)
+    parent_orgs = serializers.SerializerMethodField('get_parent_orgs')
+    badges = BadgeSerializer(many=True, required=False)
 
     def get_parent_orgs(self, obj):
         return []
@@ -361,12 +375,11 @@ class ClubSerializer(serializers.ModelSerializer):
 
         return super().save()
 
-    class Meta:
-        model = Club
-        fields = [
-            'name', 'code', 'description', 'founded', 'size', 'email', 'facebook', 'twitter', 'instagram', 'linkedin',
-            'github', 'website', 'how_to_get_involved', 'tags', 'subtitle', 'application_required',
-            'accepting_members', 'listserv', 'image_url', 'members', 'favorite_count', 'active', 'parent_orgs',
+    class Meta(ClubListSerializer.Meta):
+        fields = ClubListSerializer.Meta.fields + [
+            'facebook', 'twitter', 'instagram', 'linkedin',
+            'github', 'website', 'how_to_get_involved',
+            'listserv', 'members', 'parent_orgs',
             'badges', 'image'
         ]
 
@@ -377,7 +390,7 @@ class AuthenticatedClubSerializer(ClubSerializer):
     """
     members = AuthenticatedMembershipSerializer(many=True, source='membership_set', read_only=True)
 
-    class Meta:
+    class Meta(ClubSerializer.Meta):
         model = ClubSerializer.Meta.model
         fields = ClubSerializer.Meta.fields
 

--- a/clubs/views.py
+++ b/clubs/views.py
@@ -15,8 +15,8 @@ from rest_framework.views import APIView
 from clubs.models import Asset, Club, Event, Favorite, Membership, MembershipInvite, Tag
 from clubs.permissions import ClubPermission, EventPermission, InvitePermission, IsSuperuser, MemberPermission
 from clubs.serializers import (AssetSerializer, AuthenticatedClubSerializer, AuthenticatedMembershipSerializer,
-                               ClubSerializer, EventSerializer, FavoriteSerializer, MembershipInviteSerializer,
-                               MembershipSerializer, TagSerializer, UserSerializer)
+                               ClubListSerializer, ClubSerializer, EventSerializer, FavoriteSerializer,
+                               MembershipInviteSerializer, MembershipSerializer, TagSerializer, UserSerializer)
 
 
 def upload_endpoint_helper(request, cls, field, **kwargs):
@@ -87,6 +87,8 @@ class ClubViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'upload':
             return AssetSerializer
+        if self.action == 'list':
+            return ClubListSerializer
         if self.request is not None and self.request.user.is_authenticated:
             if 'code' in self.kwargs and (
                 self.request.user.is_superuser or


### PR DESCRIPTION
- Speed up the club list endpoint query by removing fields that are not used.
- In particular, `members`, `parent_orgs`, and `badges` would increase the lookup time because of the need for more SQL queries.