### PR TITLE
Add endpoint to resend club invite

### DIFF
--- a/clubs/serializers.py
+++ b/clubs/serializers.py
@@ -123,7 +123,7 @@ class MembershipSerializer(serializers.ModelSerializer):
 
         if membership is None or membership.role > Membership.ROLE_OFFICER:
             for field in data:
-                if field not in ['public']:
+                if field not in ['public', 'active']:
                     raise serializers.ValidationError('Normal members are not allowed to change "{}"!'.format(field))
         return data
 

--- a/clubs/serializers.py
+++ b/clubs/serializers.py
@@ -36,7 +36,8 @@ class MembershipInviteSerializer(serializers.ModelSerializer):
         if not self.validated_data.get('token') == self.instance.token:
             raise serializers.ValidationError('Missing or invalid token in request!')
 
-        if self.instance.email.endswith('.upenn.edu') and self.instance.club.membership_set.count() > 0:
+        # if there is an owner and the invite is for a upenn email, do strict username checking
+        if self.instance.email.endswith(('.upenn.edu', '@upenn.edu')) and self.instance.club.membership_set.count() > 0:
             invite_username = self.instance.email.rsplit('@', 1)[0]
             if not invite_username.lower() == user.username.lower():
                 raise serializers.ValidationError('This invitation was meant for "{}", but you are logged in as "{}"!'

--- a/clubs/views.py
+++ b/clubs/views.py
@@ -244,6 +244,15 @@ class MemberInviteViewSet(viewsets.ModelViewSet):
     serializer_class = MembershipInviteSerializer
     http_method_names = ['get', 'put', 'patch', 'delete']
 
+    @action(detail=True, methods=['put', 'patch'])
+    def resend(self, request, *args, **kwargs):
+        invite = self.get_object()
+        invite.send_mail(request)
+
+        return Response({
+            'detail': 'Resent email invitation to {}!'.format(invite.email)
+        })
+
     def get_queryset(self):
         return MembershipInvite.objects.filter(club__code=self.kwargs['club_code'], active=True)
 

--- a/tests/clubs/test_views.py
+++ b/tests/clubs/test_views.py
@@ -764,6 +764,25 @@ class ClubTestCase(TestCase):
         }, content_type='application/json')
         self.assertIn(resp.status_code, [200, 201], resp.content)
 
+        self.assertTrue(len(mail.outbox), 2)
+
+    def test_club_invite_email_resend(self):
+        self.client.login(username=self.user5.username, password='test')
+
+        resp = self.client.post(reverse('club-invite', args=(self.club1.code,)), {
+            'emails': 'test@example.upenn.edu',
+            'role': Membership.ROLE_MEMBER
+        }, content_type='application/json')
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
+        invite = MembershipInvite.objects.filter(club__code=self.club1.code).first()
+
+        resp = self.client.put(
+            reverse('club-invites-resend', args=(self.club1.code, invite.id)),
+            content_type='application/json'
+        )
+        self.assertIn(resp.status_code, [200, 201], resp.content)
+
     def test_club_invite_insufficient_auth(self):
         self.client.login(username=self.user2.username, password='test')
         Membership.objects.create(

--- a/tests/clubs/test_views.py
+++ b/tests/clubs/test_views.py
@@ -359,14 +359,14 @@ class ClubTestCase(TestCase):
             person=self.user1
         )
         self.client.login(username=self.user1.username, password='test')
-        bad_tries = [{'title': 'Supreme Leader'}, {'role': Membership.ROLE_OFFICER}, {'active': False}]
+        bad_tries = [{'title': 'Supreme Leader'}, {'role': Membership.ROLE_OFFICER}]
         for bad in bad_tries:
             resp = self.client.patch(reverse('club-members-detail', args=(self.club1.code, self.user1.username)),
                                      bad,
                                      content_type='application/json')
             self.assertIn(resp.status_code, [400, 403], resp.content)
 
-        good_tries = [{'public': True}, {'public': False}]
+        good_tries = [{'public': True}, {'public': False}, {'active': True}, {'active': False}]
         for good in good_tries:
             resp = self.client.patch(reverse('club-members-detail', args=(self.club1.code, self.user1.username)),
                                      good,


### PR DESCRIPTION
Add a `resend` endpoint that club owners/officers can use to resend an invite.